### PR TITLE
trace: add snaplen and BPF filter fields to trace modal

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -582,8 +582,10 @@
 			"down": "Nieder",
 			"download": "Trace herunterladen",
 			"duration": "Dauer",
+			"filter": "BPF Filter",
 			"network": "Netzwerk",
 			"packets": "Pakete",
+			"snaplen": "Snap Length",
 			"success": "Trace auf Gerät Nr.{{serialNumber}}abgeschlossen. Das Ergebnis können Sie jetzt herunterladen",
 			"up": "Oben",
 			"wait": "Auf die Ergebnisse warten?"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -591,6 +591,8 @@
       "duration": "Duration",
       "network": "Network",
       "packets": "Packets",
+      "filter": "BPF Filter",
+      "snaplen": "Snap Length",
       "success": "Completed trace on device #{{serialNumber}}. You can now download the result",
       "up": "Up",
       "wait": "Wait for the results?"

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -582,8 +582,10 @@
 			"down": "ABAJO",
 			"download": "Descargar seguimiento",
 			"duration": "Duración",
+			"filter": "BPF Filter",
 			"network": "Red",
 			"packets": "Paquetes",
+			"snaplen": "Snap Length",
 			"success": "Rastreo completado en el dispositivo #{{serialNumber}}. Ya puedes descargar el resultado.",
 			"up": "Arriba",
 			"wait": "¿Esperar los resultados?"

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -582,8 +582,10 @@
 			"down": "VERS LE BAS",
 			"download": "Télécharger Trace",
 			"duration": "Durée",
+			"filter": "BPF Filter",
 			"network": "Réseau",
 			"packets": "Paquets",
+			"snaplen": "Snap Length",
 			"success": "Suivi terminé sur l'appareil n° {{serialNumber}}. Vous pouvez maintenant télécharger le résultat",
 			"up": "UP",
 			"wait": "Attendre les résultats ?"

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -582,8 +582,10 @@
 			"down": "BAIXA",
 			"download": "Baixar rastreamento",
 			"duration": "Duração",
+			"filter": "BPF Filter",
 			"network": "Rede",
 			"packets": "Pacotes",
+			"snaplen": "Snap Length",
 			"success": "Rastreamento concluído no dispositivo #{{serialNumber}}. Agora você pode baixar o resultado",
 			"up": "acima",
 			"wait": "Esperar os resultados?"

--- a/src/components/Modals/TraceModal/index.tsx
+++ b/src/components/Modals/TraceModal/index.tsx
@@ -4,9 +4,16 @@ import {
   AlertIcon,
   Box,
   Button,
+  ButtonGroup,
   Center,
   FormControl,
   FormLabel,
+  Input,
+  NumberDecrementStepper,
+  NumberIncrementStepper,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
   Select,
   SimpleGrid,
   Spinner,
@@ -31,6 +38,8 @@ type FormValues = {
   waitForResponse: boolean;
   duration: string;
   packets: string;
+  snaplen: string;
+  filter: string;
 };
 
 export const TraceModal = ({ serialNumber, modalProps }: TraceModalProps) => {
@@ -41,6 +50,8 @@ export const TraceModal = ({ serialNumber, modalProps }: TraceModalProps) => {
     waitForResponse: true,
     duration: '20',
     packets: '100',
+    snaplen: '65535',
+    filter: '',
   });
   const traceDevice = useTrace({ serialNumber, alertOnCompletion: !form.waitForResponse });
   const download = useDownloadTrace({ serialNumber, commandId: traceDevice.data?.data.UUID ?? '' });
@@ -65,14 +76,17 @@ export const TraceModal = ({ serialNumber, modalProps }: TraceModalProps) => {
   };
 
   const onStart = () => {
+    const rawSnaplen = parseInt(form.snaplen, 10);
+    const snaplenValue = isNaN(rawSnaplen) ? 65535 : Math.max(1, Math.min(65535, rawSnaplen));
     traceDevice.mutate({
       serialNumber,
       type: form.type,
       network: form.network,
       waitForResponse: form.waitForResponse,
-      // @ts-ignore
       duration: form.type === 'duration' ? parseInt(form.duration, 10) : undefined,
-      packets: form.type === 'packets' ? parseInt(form.packets, 10) : undefined,
+      numberOfPackets: form.type === 'packets' ? parseInt(form.packets, 10) : undefined,
+      snaplen: snaplenValue !== 65535 ? snaplenValue : undefined,
+      filter: form.filter.trim() !== '' ? form.filter.trim() : undefined,
     });
     if (!form.waitForResponse) {
       modalProps.onClose();
@@ -164,6 +178,44 @@ export const TraceModal = ({ serialNumber, modalProps }: TraceModalProps) => {
                   name="waitForResponse"
                   isChecked={form.waitForResponse}
                   onChange={onToggleChange}
+                />
+              </FormControl>
+              <FormControl>
+                <FormLabel>{t('controller.trace.snaplen')}</FormLabel>
+                <ButtonGroup size="sm" isAttached mb={1}>
+                  {(['96', '512', '65535'] as const).map((preset) => (
+                    <Button
+                      key={preset}
+                      variant={form.snaplen === preset ? 'solid' : 'outline'}
+                      colorScheme={form.snaplen === preset ? 'blue' : 'gray'}
+                      onClick={() => setForm({ ...form, snaplen: preset })}
+                    >
+                      {preset}
+                    </Button>
+                  ))}
+                </ButtonGroup>
+                <NumberInput
+                  value={form.snaplen}
+                  min={1}
+                  max={65535}
+                  onChange={(val) => setForm({ ...form, snaplen: val })}
+                  w="120px"
+                >
+                  <NumberInputField />
+                  <NumberInputStepper>
+                    <NumberIncrementStepper />
+                    <NumberDecrementStepper />
+                  </NumberInputStepper>
+                </NumberInput>
+              </FormControl>
+              <FormControl>
+                <FormLabel>{t('controller.trace.filter')}</FormLabel>
+                <Input
+                  name="filter"
+                  value={form.filter}
+                  onChange={onFormChange}
+                  placeholder="host 192.168.1.1 and port 443"
+                  size="sm"
                 />
               </FormControl>
             </SimpleGrid>

--- a/src/hooks/Network/Trace.ts
+++ b/src/hooks/Network/Trace.ts
@@ -47,12 +47,16 @@ const startTrace = async (
         when?: number;
         network: 'up' | 'down';
         duration: number;
+        snaplen?: number;
+        filter?: string;
       }
     | {
         serialNumber: string;
         when?: number;
         network: 'up' | 'down';
         numberOfPackets: number;
+        snaplen?: number;
+        filter?: string;
       },
 ) =>
   axiosGw.post<TraceResponse>(`device/${traceData.serialNumber}/trace`, {


### PR DESCRIPTION
## Summary

Extends the Trace dialog with two new optional fields, matching the new `snaplen` and `filter` parameters added to the gateway ([wlan-cloud-ucentralgw#441](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/pull/441)) and AP handler ([wlan-ucentral-schema#101](https://github.com/Telecominfraproject/wlan-ucentral-schema/pull/101)).

**Snap Length** — limits bytes captured per packet, reducing pcap file size. Preset buttons for the three most common values (96 = headers only, 512 = headers + small payloads, 65535 = full packet) plus a free-form number input. Omitted from the POST body when set to 65535 (tcpdump's default).

**BPF Filter** — text input for a tcpdump BPF expression, e.g. `host 192.168.1.1 and port 443`. Omitted from the POST body when empty.

## Changes

- `src/hooks/Network/Trace.ts` — added `snaplen?: number` and `filter?: string` to both union members of the `startTrace` type
- `src/components/Modals/TraceModal/index.tsx` — new form fields with preset buttons, NaN/range guard on snaplen, `numberOfPackets` field name corrected (was sending `packets` due to a pre-existing `@ts-ignore`)
- `public/locales/{en,de,es,fr,pt}/translation.json` — added `controller.trace.snaplen` and `controller.trace.filter` keys to all five locales

## Testing

Tested against a self-hosted OWGW with the companion gateway build. Trace with `snaplen: 96` returned a valid pcap with capture length 96. Traces using the existing Duration/Packets modes are unaffected.